### PR TITLE
Add ARM64 in goreleaser and Travis-CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,13 @@ builds:
     main: cmd/supernode/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}
@@ -26,9 +30,13 @@ builds:
     main: cmd/dfget/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}
@@ -39,9 +47,13 @@ builds:
     main: cmd/dfdaemon/main.go
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
     ldflags:
       - -s -w -X github.com/dragonflyoss/Dragonfly/version.version={{.Version}}
       - -X github.com/dragonflyoss/Dragonfly/version.revision={{.ShortCommit}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 services:
   - docker
 sudo: false
+arch:
+  - amd64
+  - arm64
 git:
   depth: false
 language: go

--- a/Dockerfile.supernode
+++ b/Dockerfile.supernode
@@ -11,7 +11,7 @@ ARG GOPROXY
 RUN make build-supernode && make install-supernode
 RUN make build-client && make install-client
 
-FROM dragonflyoss/nginx:apline
+FROM nginx:1.19.2-alpine
 
 RUN apk --no-cache add ca-certificates bash
 


### PR DESCRIPTION
Hi,

Package Owner: Pruthvi Teja

PR change Details:

**Patch Details :** Following files has been modified :
.goreleaser.yml : arm64 goarch has been added, and jobs for darwin/arm64 have been ignored. This will create linux/arm64 release along with other amd64 releases.
.travis.yml: Added arm64 job.
Dockerfile.supernode: Replaced dragonflyoss/nginx:apline with nginx:1.19.2-apline image

**Testing Detail :**
We need to install goreleaser on our system, generate and set the GITHUB_TOKEN, generate a tag, and push it to our forked repo. Then in the root of our repo, we need to run 'goreleaser' command. That will upload releases to our forked repo.

**Reviewer Comment :** < To be filled by Reviewer >

**PR Description :** 

- Updated the .goreleaser.yml file to generate linux/arm64 binaries.
- Added arm64 job in Travis-CI.
- Replaced dragonflyoss/nginx:apline with nginx:1.19.2-apline image for supernode image

Signed-off-by: odidev odidev@puresoftware.com

**Reviewer:** Shobhit Parashari